### PR TITLE
Test random indicators and intercept JSONDecodeError

### DIFF
--- a/tests/test_indicator.py
+++ b/tests/test_indicator.py
@@ -1,5 +1,6 @@
 import pytest
 import numbers
+import random
 from world_bank_data import get_indicators, get_series
 from .tools import assert_numeric_or_string
 from pandas.testing import assert_frame_equal
@@ -95,3 +96,24 @@ def test_indicator_monthly():
     idx = get_series('DPANUSSPB', country=['CHN', 'BRA'], date='2012M01:2012M08')
     assert len(idx.index) > 200 * 12
     assert_numeric_or_string(idx)
+
+
+def random_indicators():
+    random.seed(2019)
+    all_indicators = get_indicators()
+    return random.sample(all_indicators.index.tolist(), 12)
+
+
+@pytest.mark.parametrize('indicator', random_indicators())
+def test_random_indicators(indicator):
+    try:
+        idx = get_series(indicator, mrv=1)
+        assert_numeric_or_string(idx)
+    except ValueError as err:
+        assert 'The indicator was not found' in str(err)
+
+
+def test_json_error():
+    indicator = 'NV.IND.MANF.KD.87'
+    with pytest.raises(ValueError, match='The indicator was not found. It may have been deleted or archived.'):
+        get_series(indicator, mrv=1)

--- a/world_bank_data/request.py
+++ b/world_bank_data/request.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Request the world bank API"""
 import re
 import json


### PR DESCRIPTION
As suggested by @bcipolli at #7.

With this update, we get the following output:
```
ENF.CONT.COEN.CSMG: OK
IN.IS.RRS.PASG.KM.SUB: OK
UIS.NAR.2: OK
FB.FCP.INST.CB.PD.SW: OK
IP.TMK.RSCT: OK
IT.NET.BNDW.PC: OK
per_lm_pa.adq_q2_preT_tot: OK
NV.IND.MANF.KD.87: ERROR:
The indicator was not found. It may have been deleted or archived.
url=http://api.worldbank.org/v2/country/all/indicator/NV.IND.MANF.KD.87
params={'mrv': 1, 'format': 'jsonstat', 'per_page': 20000}
SABER.WORK.GOAL2: OK
IN.EC.POP.RURL.PCT: OK
SE.SEC.PROG.MA.ZS: OK
SN.ITK.VITA.Q5.ZS: OK
```

for this code snippet:
```python
import sys
import random
import world_bank_data as wb

all_indics = wb.get_indicators()

random.seed(2019)
for indicator in random.sample(all_indics.index.tolist(), 12):
    sys.stdout.write(indicator + ':')
    try:
        value = wb.get_series(indicator, mrv=1)
        sys.stdout.write(' OK\n')
    except ValueError as err:
        sys.stdout.write(' ERROR:\n')
        sys.stdout.write(str(err) + '\n')
```