### PR TITLE
Use HTTPS for WB API

### DIFF
--- a/world_bank_data/request.py
+++ b/world_bank_data/request.py
@@ -9,7 +9,7 @@ import pandas as pd
 from cachetools import cached, TTLCache, keys
 import world_bank_data.options as options
 
-WORLD_BANK_URL = 'http://api.worldbank.org/v2'
+WORLD_BANK_URL = 'https://api.worldbank.org/v2'
 
 
 class WBRequestError(HTTPError):


### PR DESCRIPTION
The WB HTTP API URL is no longer working for me, switching the default API URL to HTTPS fixed it.

I think it should be HTTPS anyway?